### PR TITLE
DFP-20: Crear endpoint para actualizar una asignación existente entre un vehículo y conductor

### DIFF
--- a/back-end/src/assignments/assignments.service.ts
+++ b/back-end/src/assignments/assignments.service.ts
@@ -81,8 +81,85 @@ export class AssignmentsService {
     return `This action returns a #${id} assignment`;
   }
 
-  update(id: string, updateAssignmentDto: UpdateAssignmentDto) {
-    return `This action updates a #${id} assignment`;
+  async update(id: string, updateAssignmentDto: UpdateAssignmentDto) {
+    const { vehicleId, driverId, assignmentDate } = updateAssignmentDto;
+
+    // Buscar la asignación existente
+    const existingAssignment = await this.findOne(id);
+
+    // Verificar si se está cambiando el conductor
+    if (driverId && driverId !== existingAssignment.driver.id) {
+      const newDriver = await this.driverService.findOne(driverId);
+      if (newDriver.assigned) {
+        this.exceptionService.throwConflictException("Driver", newDriver.id);
+      }
+    }
+
+    // Verificar si se está cambiando el vehículo
+    if (vehicleId && vehicleId !== existingAssignment.vehicle.id) {
+      const newVehicle = await this.vehicleService.findOne(vehicleId);
+      if (newVehicle.assigned) {
+        this.exceptionService.throwConflictException("Vehicle", newVehicle.id);
+      }
+    }
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+        // Actualizar estados de los recursos anteriores
+        if (driverId && driverId !== existingAssignment.driver.id) {
+          existingAssignment.driver.assigned = false;
+          await queryRunner.manager.save(Driver, existingAssignment.driver);
+        }
+        
+        if (vehicleId && vehicleId !== existingAssignment.vehicle.id) {
+          existingAssignment.vehicle.assigned = false;
+          await queryRunner.manager.save(Vehicle, existingAssignment.vehicle);
+        }
+
+        // Obtener los nuevos recursos si cambiaron
+        const newDriver = driverId ? await this.driverService.findOne(driverId) : existingAssignment.driver;
+        const newVehicle = vehicleId ? await this.vehicleService.findOne(vehicleId) : existingAssignment.vehicle;
+
+        // Actualizar la asignación
+        existingAssignment.driver = newDriver;
+        existingAssignment.vehicle = newVehicle;
+        existingAssignment.driver = newDriver;
+        existingAssignment.vehicle = newVehicle;
+        if (assignmentDate) {
+          existingAssignment.assignmentDate = assignmentDate;
+        }
+        await queryRunner.manager.save(existingAssignment);
+
+        // Actualizar estados de los nuevos recursos
+        if (driverId && driverId !== existingAssignment.driver.id) {
+          newDriver.assigned = true;
+          await queryRunner.manager.save(Driver, newDriver);
+        }
+        
+        if (vehicleId && vehicleId !== existingAssignment.vehicle.id) {
+          newVehicle.assigned = true;
+          await queryRunner.manager.save(Vehicle, newVehicle);
+        }
+
+        // Registrar en el historial
+        const assignmentHistory = this.assignmentHistoryRepository.create({
+          driver: newDriver,
+          vehicle: newVehicle
+        });
+        await queryRunner.manager.save(AssignmentHistory, assignmentHistory);
+
+        await queryRunner.commitTransaction();
+        await queryRunner.release();
+
+        return existingAssignment;
+    } catch (error) {
+        await queryRunner.rollbackTransaction();
+        await queryRunner.release();
+        this.exceptionService.handleDBExceptions(error);
+    }
   }
 
   remove(id: string) {


### PR DESCRIPTION
# DFP-20: Crear endpoint para actualizar una asignación existente entre un vehículo y conductor

## 1. Descripción general

Crear endpoint PATCH `/api/assigments/{id}` para actualizar información parcial de una asignación existente mediante su ID.

## 2. Solicitud

EndPoint: `PATCH /api/assigments/{id}`

Payload(Ejemplo):

```
{
  "vehicleId": "miw0382j3-jr83-830j-9b5b-8392jhei03ke",
  "driverId": "68bf9f05-dca5-4d1b-a61f-802fdc958932", 
  "assigmentDate": "2024-05-15"
}
```

Flujo de operación

- 1: Cambiar el estado del atributo assigned a False tanto para el vehículo y el conductor
- 2: Crear la nueva asignación del conductor
- 3: Crear el nuevo registro en la tabla assigment
- 4: Crear nuevo registro en la tabla assigmentHistory

## 3. Criterios de aceptación 

✅ Actualiza solo los campos proporcionados en el payload
✅ Retorna 200 OK con el objeto actualizado
✅ Retorna 404 Not Found si la asignación no existe
✅ Retorna 400 Bad Request para datos inválidos

## 4 Recursos

N/A