### PR TITLE
DFP 23 Crear endpoint para eliminar una asignacion

### DIFF
--- a/back-end/src/assignments/assignments.service.ts
+++ b/back-end/src/assignments/assignments.service.ts
@@ -168,7 +168,8 @@ export class AssignmentsService {
     }
   }
 
-  remove(id: string) {
-    return `This action removes a #${id} assignment`;
+  async remove(id: string) {
+    const assignment = await this.findOne(id);
+    await this.assignmentRepository.remove(assignment);
   }
 }

--- a/back-end/src/assignments/assignments.service.ts
+++ b/back-end/src/assignments/assignments.service.ts
@@ -143,8 +143,6 @@ export class AssignmentsService {
       // Update the assignment
       existingAssignment.driver = newDriver;
       existingAssignment.vehicle = newVehicle;
-      existingAssignment.driver = newDriver;
-      existingAssignment.vehicle = newVehicle;
       if (assignmentDate) {
         existingAssignment.assignmentDate = assignmentDate;
       }
@@ -170,6 +168,36 @@ export class AssignmentsService {
 
   async remove(id: string) {
     const assignment = await this.findOne(id);
-    await this.assignmentRepository.remove(assignment);
+    if(!assignment) this.exceptionService.throwNotFound('Assignment', id)
+
+    const driver = await this.driverService.findOne(assignment.driver.id);
+
+    if(!assignment) this.exceptionService.throwNotFound('Diver', assignment.driver.id)
+
+    const vehicle = await this.vehicleService.findOne(assignment.vehicle.id);
+
+    if(!assignment) this.exceptionService.throwNotFound('Vehicle', assignment.vehicle.id)
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      //Change the "assigned" value of the related driver and vehicle
+      driver.assigned = false;
+      await queryRunner.manager.save(Driver, driver);
+      vehicle.assigned = false;
+      await queryRunner.manager.save(Vehicle, vehicle);
+
+      await this.assignmentRepository.remove(assignment);
+
+      await queryRunner.commitTransaction();
+      await queryRunner.release();
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      await queryRunner.release();
+      this.exceptionService.handleDBExceptions(error);
+    }
+    
   }
 }


### PR DESCRIPTION
# DFP-23: Crear endpoint para eliminar una asignación
## 1. Descripción general
Crear endpoint DELETE `/api/assigment/{id}` para obtener una asignación específica previamente registrada.

## 2. Solicitud
EndPoint: DELETE `/api/assigment/{id}`

### Flujo de operación

1: Cambiar el estado del atributo assigned a False tanto para el vehículo y el conductor

2: Eliminar la asignación

## 3. Criterios de aceptación
✅ Retorna 204 No Content al eliminar correctamente
✅ Retorna 404 Not Found si el ID no existe
## 4. Recursos
N/A