### PR TITLE
DFP-16 Crear endpoint para actualizar una ruta

### DIFF
--- a/back-end/src/routes/routes.service.ts
+++ b/back-end/src/routes/routes.service.ts
@@ -48,10 +48,21 @@ export class RoutesService {
     return `This action returns a #${id} route`;
   }
 
-  update(id: string, updateRouteDto: UpdateRouteDto) {
-    return `This action updates a #${id} route`;
-  }
+  async update(id: string, updateRouteDto: UpdateRouteDto) {
+    const route = await this.routeRepository.preload({
+      id,
+      ...updateRouteDto,
+    });
 
+    if (!route) this.exceptionService.throwNotFound("Route", id);
+
+    try {
+      return await this.routeRepository.save(route);
+    } catch (error) {
+      this.exceptionService.handleDBExceptions(error);
+    }
+  }  
+  
   remove(id: string) {
     return `This action removes a #${id} route`;
   }

--- a/back-end/src/routes/routes.service.ts
+++ b/back-end/src/routes/routes.service.ts
@@ -52,9 +52,8 @@ export class RoutesService {
   }
 
   async update(id: string, updateRouteDto: UpdateRouteDto) {
-    const validRoute = await this.findOne(id);
 
-    if(!validRoute) this.exceptionService.throwNotFound("Route", id);
+    if(updateRouteDto.assignmentId) this.assignmentsService.findOne(updateRouteDto.assignmentId);
 
     const route = await this.routeRepository.preload({
       id,


### PR DESCRIPTION
# DFP-16: Crear endpoint para actualizar una ruta
## 1. Descripción general
Crear endpoint PATCH `/api/routes` para actualizar información parcial de una ruta existente mediante su ID.

## 2. Solicitud
EndPoint: PATCH/api/routes/{id}

Payload(Ejemplo):
```
{
  "latitudeDestiny": 472047,
  "lengthDestiny": 729382,
  "creationDate": "04-12-2025"
}
```
## 3. Criterios de aceptación
✅ Actualiza solo los campos proporcionados en el payload
✅ Retorna 200 OK con el objeto actualizado
✅ Retorna 404 Not Found si la ruta no existe
✅ Retorna 400 Bad Request para datos inválidos
## 4. Recursos
N/A