### PR TITLE
DFP-26 Agregar validación de autenticación

### DIFF
--- a/back-end/src/assignments/assignments.controller.ts
+++ b/back-end/src/assignments/assignments.controller.ts
@@ -1,33 +1,39 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards } from '@nestjs/common';
 import { AssignmentsService } from './assignments.service';
 import { CreateAssignmentDto } from './dto/create-assignment.dto';
 import { UpdateAssignmentDto } from './dto/update-assignment.dto';
+import { AuthGuard } from '@nestjs/passport';
 
 @Controller('assignments')
 export class AssignmentsController {
   constructor(private readonly assignmentsService: AssignmentsService) {}
 
   @Post()
+  @UseGuards(AuthGuard('jwt'))
   create(@Body() createAssignmentDto: CreateAssignmentDto) {
     return this.assignmentsService.create(createAssignmentDto);
   }
 
   @Get()
+  @UseGuards(AuthGuard('jwt'))
   findAll() {
     return this.assignmentsService.findAll();
   }
 
   @Get(':id')
+  @UseGuards(AuthGuard('jwt'))
   findOne(@Param('id') id: string) {
     return this.assignmentsService.findOne(id);
   }
 
   @Patch(':id')
+  @UseGuards(AuthGuard('jwt'))
   update(@Param('id') id: string, @Body() updateAssignmentDto: UpdateAssignmentDto) {
     return this.assignmentsService.update(id, updateAssignmentDto);
   }
 
   @Delete(':id')
+  @UseGuards(AuthGuard('jwt'))
   remove(@Param('id') id: string) {
     return this.assignmentsService.remove(id);
   }

--- a/back-end/src/assignments/assignments.module.ts
+++ b/back-end/src/assignments/assignments.module.ts
@@ -3,6 +3,7 @@ import { AssignmentsService } from './assignments.service';
 import { AssignmentsController } from './assignments.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommonModule } from 'src/common/common.module';
+import { AuthModule } from 'src/auth/auth.module';
 import { Assignment, AssignmentHistory } from './entities';
 import { Driver } from 'src/drivers/entities';
 import { Vehicle } from 'src/vehicles/entities';
@@ -15,7 +16,8 @@ import { Route } from 'src/routes/entities';
   providers: [AssignmentsService, DriversService, VehiclesService],
   imports: [
     TypeOrmModule.forFeature([ Assignment, AssignmentHistory, Vehicle, Route, Driver ]),
-    CommonModule
+    CommonModule,
+    AuthModule
   ],
   exports: [AssignmentsService]
 })

--- a/back-end/src/drivers/drivers.controller.ts
+++ b/back-end/src/drivers/drivers.controller.ts
@@ -1,33 +1,39 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards } from '@nestjs/common';
 import { DriversService } from './drivers.service';
 import { CreateDriverDto } from './dto/create-driver.dto';
 import { UpdateDriverDto } from './dto/update-driver.dto';
+import { AuthGuard } from '@nestjs/passport';
 
 @Controller('drivers')
 export class DriversController {
   constructor(private readonly driversService: DriversService) {}
 
   @Post()
+  @UseGuards(AuthGuard('jwt'))
   create(@Body() createDriverDto: CreateDriverDto) {
     return this.driversService.create(createDriverDto);
   }
 
   @Get()
+  @UseGuards(AuthGuard('jwt'))
   findAll() {
     return this.driversService.findAll();
   }
 
   @Get(':id')
+  @UseGuards(AuthGuard('jwt'))
   findOne(@Param('id') id: string) {
     return this.driversService.findOne(id);
   }
 
   @Patch(':id')
+  @UseGuards(AuthGuard('jwt'))
   update(@Param('id') id: string, @Body() updateDriverDto: UpdateDriverDto) {
     return this.driversService.update(id, updateDriverDto);
   }
 
   @Delete(':id')
+  @UseGuards(AuthGuard('jwt'))
   remove(@Param('id') id: string) {
     return this.driversService.remove(id);
   }

--- a/back-end/src/drivers/drivers.module.ts
+++ b/back-end/src/drivers/drivers.module.ts
@@ -4,6 +4,7 @@ import { DriversController } from './drivers.controller';
 import { Driver } from './entities';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommonModule } from 'src/common/common.module';
+import { AuthModule } from 'src/auth/auth.module';
 import { Assignment } from 'src/assignments/entities';
 
 @Module({
@@ -11,7 +12,8 @@ import { Assignment } from 'src/assignments/entities';
   providers: [DriversService],
   imports: [
     TypeOrmModule.forFeature([ Driver, Assignment ]),
-    CommonModule
+    CommonModule,
+    AuthModule
   ],
 })
 export class DriversModule {}

--- a/back-end/src/routes/routes.controller.ts
+++ b/back-end/src/routes/routes.controller.ts
@@ -1,33 +1,39 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards } from '@nestjs/common';
 import { RoutesService } from './routes.service';
 import { CreateRouteDto } from './dto/create-route.dto';
 import { UpdateRouteDto } from './dto/update-route.dto';
+import { AuthGuard } from '@nestjs/passport';
 
 @Controller('routes')
 export class RoutesController {
   constructor(private readonly routesService: RoutesService) {}
 
   @Post()
+  @UseGuards(AuthGuard('jwt'))
   create(@Body() createRouteDto: CreateRouteDto) {
     return this.routesService.create(createRouteDto);
   }
 
   @Get()
+  @UseGuards(AuthGuard('jwt'))
   findAll() {
     return this.routesService.findAll();
   }
 
   @Get(':id')
+  @UseGuards(AuthGuard('jwt'))
   findOne(@Param('id') id: string) {
     return this.routesService.findOne(id);
   }
 
   @Patch(':id')
+  @UseGuards(AuthGuard('jwt'))
   update(@Param('id') id: string, @Body() updateRouteDto: UpdateRouteDto) {
     return this.routesService.update(id, updateRouteDto);
   }
 
   @Delete(':id')
+  @UseGuards(AuthGuard('jwt'))
   remove(@Param('id') id: string) {
     return this.routesService.remove(id);
   }

--- a/back-end/src/routes/routes.module.ts
+++ b/back-end/src/routes/routes.module.ts
@@ -5,6 +5,7 @@ import { Assignment, AssignmentHistory } from 'src/assignments/entities';
 import { Route } from './entities';
 import { CommonModule } from 'src/common/common.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from 'src/auth/auth.module';
 import { AssignmentsService } from 'src/assignments/assignments.service';
 import { DriversService } from 'src/drivers/drivers.service';
 import { Vehicle } from 'src/vehicles/entities';
@@ -17,6 +18,7 @@ import { VehiclesService } from 'src/vehicles/vehicles.service';
   imports: [
     TypeOrmModule.forFeature([ Assignment, AssignmentHistory, Vehicle, Route, Driver ]),
     CommonModule,
+    AuthModule
   ],
 })
 export class RoutesModule {}

--- a/back-end/src/vehicles/vehicles.controller.ts
+++ b/back-end/src/vehicles/vehicles.controller.ts
@@ -1,33 +1,39 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards } from '@nestjs/common';
 import { VehiclesService } from './vehicles.service';
 import { CreateVehicleDto } from './dto/create-vehicle.dto';
 import { UpdateVehicleDto } from './dto/update-vehicle.dto';
+import { AuthGuard } from '@nestjs/passport';
 
 @Controller('vehicles')
 export class VehiclesController {
   constructor(private readonly vehiclesService: VehiclesService) {}
 
   @Post()
+  @UseGuards(AuthGuard('jwt'))
   create(@Body() createVehicleDto: CreateVehicleDto) {
     return this.vehiclesService.create(createVehicleDto);
   }
 
   @Get()
+  @UseGuards(AuthGuard('jwt'))
   findAll() {
     return this.vehiclesService.findAll();
   }
 
   @Get(':id')
+  @UseGuards(AuthGuard('jwt'))
   findOne(@Param('id') id: string) {
     return this.vehiclesService.findOne(id);
   }
 
   @Patch(':id')
+  @UseGuards(AuthGuard('jwt'))
   update(@Param('id') id: string, @Body() updateVehicleDto: UpdateVehicleDto) {
     return this.vehiclesService.update(id, updateVehicleDto);
   }
 
   @Delete(':id')
+  @UseGuards(AuthGuard('jwt'))
   remove(@Param('id') id: string) {
     return this.vehiclesService.remove(id);
   }

--- a/back-end/src/vehicles/vehicles.module.ts
+++ b/back-end/src/vehicles/vehicles.module.ts
@@ -4,6 +4,7 @@ import { VehiclesController } from './vehicles.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Vehicle } from './entities';
 import { CommonModule } from 'src/common/common.module';
+import { AuthModule } from 'src/auth/auth.module';
 import { Assignment } from 'src/assignments/entities';
 
 @Module({
@@ -11,7 +12,8 @@ import { Assignment } from 'src/assignments/entities';
   providers: [VehiclesService],
   imports: [
     TypeOrmModule.forFeature([ Vehicle, Assignment ]),
-    CommonModule
+    CommonModule,
+    AuthModule
   ],
 })
 export class VehiclesModule {}


### PR DESCRIPTION
# DFP-26: Agregar validación de autenticación
## 1. Descripción general
Añadir validaciones de token de autenticación a los endpoints establecidos.

## 2. Solicitud
Aplica para los endpoints de edición y obtención de datos como vehículos o conductores.

## 3. Criterios de aceptación
✅ Retorna 200 con el objeto completo

✅ Retorna 400 con errores específicos si hay datos inválidos.
✅ Retorna 401 cuando las credenciales son incorrrectas.

## 4. Recursos
N/A