### PR TITLE
DFP-41 Corregir el envio de mensaje al eliminar una entidad que esta relaciona con otras tablas

### DIFF
--- a/back-end/src/common/common.module.ts
+++ b/back-end/src/common/common.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ExceptionService } from './exception.service';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
+  imports: [ConfigModule.forRoot()],
   providers: [ExceptionService],
   exports: [ExceptionService]
 })

--- a/back-end/src/common/exception.service.ts
+++ b/back-end/src/common/exception.service.ts
@@ -1,8 +1,11 @@
 import { Injectable, Logger, BadRequestException, InternalServerErrorException, NotFoundException, ConflictException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class ExceptionService {
   private readonly logger = new Logger(ExceptionService.name);
+
+  constructor(private readonly configService: ConfigService) {}
 
   handleDBExceptions(error: any): never {
     if (error.code === '23505') {
@@ -10,7 +13,9 @@ export class ExceptionService {
     }
 
     this.logger.error(error);
-    throw new InternalServerErrorException('Unexpected error, check server logs');
+    const isDev = this.configService.get<string>('NODE_ENV') !== 'production';
+    const message = isDev ? 'Unexpected error, check server logs' : 'Internal server error';
+    throw new InternalServerErrorException(message);
   }
 
   throwNotFound(resource: string, id: string): never {

--- a/back-end/src/drivers/drivers.service.ts
+++ b/back-end/src/drivers/drivers.service.ts
@@ -73,9 +73,14 @@ export class DriversService {
   }
 
   async remove(id: string) {
-    winstonLogger.debug(`[DriversService] Deleting driver with ID: ${id}`);
-    const driver = await this.findOne(id);
-    await this.driverRepository.remove(driver);
-    winstonLogger.info(`[DriversService] Driver deleted with ID: ${id}`);
+    try {
+      winstonLogger.debug(`[DriversService] Deleting driver with ID: ${id}`);
+      const driver = await this.findOne(id);
+      await this.driverRepository.remove(driver);
+      winstonLogger.info(`[DriversService] Driver deleted with ID: ${id}`);
+    } catch (error) {
+      winstonLogger.error(`[DriversService] Error while deleting driver: ${error.message}`);
+      this.exceptionService.handleDBExceptions(error);
+    }
   }
 }

--- a/back-end/src/routes/routes.service.ts
+++ b/back-end/src/routes/routes.service.ts
@@ -105,9 +105,14 @@ export class RoutesService {
   }
 
   async remove(id: string) {
-    winstonLogger.debug(`[RoutesService] Deleting route with ID: ${id}`);
-    const route = await this.findOne(id);
-    await this.routeRepository.remove(route);
-    winstonLogger.info(`[RoutesService] Route deleted with ID: ${id}`);
+    try {
+      winstonLogger.debug(`[RoutesService] Deleting route with ID: ${id}`);
+      const route = await this.findOne(id);
+      await this.routeRepository.remove(route);
+      winstonLogger.info(`[RoutesService] Route deleted with ID: ${id}`);
+    } catch (error) {
+      winstonLogger.error(`[RoutesService] Error while deleting route: ${error.message}`);
+      this.exceptionService.handleDBExceptions(error);
+    }
   }
 }

--- a/back-end/src/vehicles/vehicles.service.ts
+++ b/back-end/src/vehicles/vehicles.service.ts
@@ -72,9 +72,14 @@ export class VehiclesService {
   }
 
   async remove(id: string) {
-    winstonLogger.debug(`[VehicleService] Deleting vehicle with ID: ${id}`);
-    const vehicle = await this.findOne(id);
-    await this.vehicleRepository.remove(vehicle);
-    winstonLogger.info(`[VehicleService] Vehicle deleted with ID: ${id}`);
+    try {
+      winstonLogger.debug(`[VehicleService] Deleting vehicle with ID: ${id}`);
+      const vehicle = await this.findOne(id);
+      await this.vehicleRepository.remove(vehicle);
+      winstonLogger.info(`[VehicleService] Vehicle deleted with ID: ${id}`);
+    } catch (error) {
+      winstonLogger.error(`[VehicleService] Error while deleting vehicle: ${error.message}`);
+      this.exceptionService.handleDBExceptions(error);
+    }
   }
 }


### PR DESCRIPTION
# DFP-41 Corregir el envio de mensaje al eliminar una entidad que esta relaciona con otras tablas
## 1. Descripción general
Al intentar eliminar una entidad que posee relaciones con otras tablas (por ejemplo, claves foráneas en uso), el sistema responde con un error 500 acompañado de un mensaje no adecuado para producción, el cual no es útil para el usuario final.

El objetivo es capturar esta situación específica y enviar un mensaje más claro y controlado, manteniendo el nivel de log adecuado y evitando que se revele información técnica innecesaria.

## 2. Solicitud

- Identificar los casos en que se produce un error por restricción de integridad referencial (foreign key constraint).
- Actualizar el ExceptionServicecapturar este tipo de error (por ejemplo, código SQL 23503 en PostgreSQL).
- Garantizar que en modo debug (NODE_ENV=development), se incluya el error técnico completo en los logs, pero que en producción solo se muestre el mensaje controlado al usuario.

## 3. Criterios de aceptación
✅ El sistema muestra un mensaje claro y controlado cuando ocurre un error de eliminación por relaciones con otras tablas, y este mensaje varía según el entorno:
- En producción: mensaje amigable sin detalles técnicos.
- En desarrollo: mensaje con detalles técnicos incluidos.

## 4. Recursos
N/A