### PR TITLE
DFP-48 Generar métricas de la aplicación

### DIFF
--- a/back-end/src/app.module.ts
+++ b/back-end/src/app.module.ts
@@ -7,6 +7,7 @@ import { DriversModule } from './drivers/drivers.module';
 import { AssignmentsModule } from './assignments/assignments.module';
 import { RoutesModule } from './routes/routes.module';
 import { AuthModule } from './auth/auth.module';
+import { DashboardModule } from './dashboard/dashboard.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { AuthModule } from './auth/auth.module';
     AssignmentsModule,
     RoutesModule,
     AuthModule,
+    DashboardModule,
   ],
 })
 export class AppModule {}

--- a/back-end/src/assignments/assignments.service.ts
+++ b/back-end/src/assignments/assignments.service.ts
@@ -19,8 +19,8 @@ export class AssignmentsService {
     @InjectRepository(AssignmentHistory)
     private readonly assignmentHistoryRepository: Repository<AssignmentHistory>,
     private readonly dataSource: DataSource,
-    private readonly driverService: DriversService,
-    private readonly vehicleService: VehiclesService,
+    private readonly driversService: DriversService,
+    private readonly vehiclesService: VehiclesService,
     private readonly exceptionService: ExceptionService,
   ) {}
 
@@ -29,13 +29,13 @@ export class AssignmentsService {
 
     winstonLogger.info(`[AssignmentsService] Creating new assignment: driverId=${driverId}, vehicleId=${vehicleId}`);
 
-    const assignedDriver = await this.driverService.findOne(driverId);
+    const assignedDriver = await this.driversService.findOne(driverId);
     if (assignedDriver.assigned) {
       winstonLogger.warn(`[AssignmentsService] Driver ${driverId} is already assigned`);
       this.exceptionService.throwConflictException('Driver', assignedDriver.id);
     }
 
-    const assignedVehicle = await this.vehicleService.findOne(vehicleId);
+    const assignedVehicle = await this.vehiclesService.findOne(vehicleId);
     if (assignedVehicle.assigned) {
       winstonLogger.warn(`[AssignmentsService] Vehicle ${vehicleId} is already assigned`);
       this.exceptionService.throwConflictException('Vehicle', assignedVehicle.id);
@@ -112,7 +112,7 @@ export class AssignmentsService {
     const existingAssignment = await this.findOne(id);
 
     if (driverId && driverId !== existingAssignment.driver.id) {
-      const newDriver = await this.driverService.findOne(driverId);
+      const newDriver = await this.driversService.findOne(driverId);
       if (newDriver.assigned) {
         winstonLogger.warn(`[AssignmentsService] New driver ${driverId} is already assigned`);
         this.exceptionService.throwConflictException('Driver', newDriver.id);
@@ -120,7 +120,7 @@ export class AssignmentsService {
     }
 
     if (vehicleId && vehicleId !== existingAssignment.vehicle.id) {
-      const newVehicle = await this.vehicleService.findOne(vehicleId);
+      const newVehicle = await this.vehiclesService.findOne(vehicleId);
       if (newVehicle.assigned) {
         winstonLogger.warn(`[AssignmentsService] New vehicle ${vehicleId} is already assigned`);
         this.exceptionService.throwConflictException('Vehicle', newVehicle.id);
@@ -142,8 +142,8 @@ export class AssignmentsService {
         await queryRunner.manager.save(Vehicle, existingAssignment.vehicle);
       }
 
-      const newDriver = driverId ? await this.driverService.findOne(driverId) : existingAssignment.driver;
-      const newVehicle = vehicleId ? await this.vehicleService.findOne(vehicleId) : existingAssignment.vehicle;
+      const newDriver = driverId ? await this.driversService.findOne(driverId) : existingAssignment.driver;
+      const newVehicle = vehicleId ? await this.vehiclesService.findOne(vehicleId) : existingAssignment.vehicle;
 
       if (driverId && driverId !== existingAssignment.driver.id) {
         newDriver.assigned = true;
@@ -184,8 +184,8 @@ export class AssignmentsService {
   async remove(id: string) {
     winstonLogger.debug(`[AssignmentsService] Removing assignment with ID: ${id}`);
     const assignment = await this.findOne(id);
-    const driver = await this.driverService.findOne(assignment.driver.id);
-    const vehicle = await this.vehicleService.findOne(assignment.vehicle.id);
+    const driver = await this.driversService.findOne(assignment.driver.id);
+    const vehicle = await this.vehiclesService.findOne(assignment.vehicle.id);
 
     const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();

--- a/back-end/src/auth/auth.controller.ts
+++ b/back-end/src/auth/auth.controller.ts
@@ -27,4 +27,10 @@ export class AuthController {
   ) {
     return this.authService.createInvitation(user);
   }
+
+  @Get()
+  @UseGuards(JwtAuthGuard)
+  findAll() {
+    return this.authService.findAll();
+  }
 }

--- a/back-end/src/auth/auth.module.ts
+++ b/back-end/src/auth/auth.module.ts
@@ -32,5 +32,6 @@ import { CommonModule } from 'src/common/common.module';
       }
     })
   ],
+  exports: [AuthService, JwtModule]
 })
 export class AuthModule {}

--- a/back-end/src/auth/auth.service.ts
+++ b/back-end/src/auth/auth.service.ts
@@ -154,4 +154,14 @@ export class AuthService {
     winstonLogger.debug(`[AuthService] Generated JWT for payload: ${JSON.stringify(payload)}`);
     return token;
   }
+
+  async findAll() {
+    try {
+      winstonLogger.debug('[AuthService] Retrieving all users');
+      return this.userRepository.find();
+    } catch (error) {
+      winstonLogger.error(`[AuthService] Error while retrieving users: ${error.message}`);
+      this.exceptionService.handleDBExceptions(error);
+    }
+  }
 }

--- a/back-end/src/dashboard/dashboard.controller.ts
+++ b/back-end/src/dashboard/dashboard.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { DashboardService } from './dashboard.service';
+
+@Controller('dashboard')
+export class DashboardController {
+  constructor(private readonly dashboardService: DashboardService) {}
+
+  @Get('metrics')
+  getDashboardMetrics() {
+    return this.dashboardService.getMetrics();
+  }
+}

--- a/back-end/src/dashboard/dashboard.module.ts
+++ b/back-end/src/dashboard/dashboard.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common';
+import { DashboardService } from './dashboard.service';
+import { DashboardController } from './dashboard.controller';
+import { AuthService } from 'src/auth/auth.service';
+import { VehiclesService } from 'src/vehicles/vehicles.service';
+import { DriversService } from 'src/drivers/drivers.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CommonModule } from 'src/common/common.module';
+import { AuthModule } from 'src/auth/auth.module';
+import { Vehicle } from 'src/vehicles/entities';
+import { Driver } from 'src/drivers/entities';
+import { Invitation, User } from 'src/auth/entities';
+import { Route } from 'src/routes/entities';
+import { RoutesService } from 'src/routes/routes.service';
+import { AssignmentsModule } from 'src/assignments/assignments.module';
+
+@Module({
+  controllers: [DashboardController],
+  providers: [DashboardService, DriversService, VehiclesService, AuthService, RoutesService,],
+  imports: [
+    TypeOrmModule.forFeature([ Vehicle, Driver, User, Route, Invitation]),
+    CommonModule,
+    AuthModule,
+    AssignmentsModule
+  ],
+})
+export class DashboardModule {}

--- a/back-end/src/dashboard/dashboard.service.ts
+++ b/back-end/src/dashboard/dashboard.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { AuthService } from 'src/auth/auth.service';
+import { DriversService } from 'src/drivers/drivers.service';
+import { VehiclesService } from 'src/vehicles/vehicles.service';
+import { ExceptionService } from 'src/common/exception.service';
+import { winstonLogger } from 'src/common/utils/loggers';
+import { RoutesService } from 'src/routes/routes.service';
+
+@Injectable()
+export class DashboardService {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly driversService: DriversService,
+    private readonly vehiclesService: VehiclesService,
+    private readonly routesService: RoutesService,
+    private readonly exceptionService: ExceptionService,
+  ) {}
+
+  async getMetrics() {
+    winstonLogger.debug('[DashboardService] Fetching dashboard metrics...');
+
+    try {
+      const [users, vehicles, drivers, routesToday] = await Promise.all([
+        this.authService.findAll(),
+        this.vehiclesService.findAll(),
+        this.driversService.findAll(),
+        this.routesService.findToday(),
+      ]);
+
+      const result = {
+        users: users.length,
+        vehicles: vehicles.length,
+        drivers: drivers.length,
+        routesToday: routesToday.length,
+      };
+
+      winstonLogger.info(`[DashboardService] Dashboard metrics: ${JSON.stringify(result)}`);
+      return result;
+    } catch (error) {
+      winstonLogger.error(`[DashboardService] Failed to fetch dashboard metrics: ${error.message}`);
+      this.exceptionService.handleDBExceptions(error);
+    }
+  }
+}

--- a/back-end/src/routes/routes.service.ts
+++ b/back-end/src/routes/routes.service.ts
@@ -7,6 +7,7 @@ import { Repository } from 'typeorm';
 import { ExceptionService } from 'src/common/exception.service';
 import { AssignmentsService } from 'src/assignments/assignments.service';
 import { winstonLogger } from 'src/common/utils/loggers';
+import { Between } from 'typeorm';
 
 @Injectable()
 export class RoutesService {
@@ -57,6 +58,31 @@ export class RoutesService {
       return routes;
     } catch (error) {
       winstonLogger.error(`[RoutesService] Error while retrieving routes: ${error.message}`);
+      this.exceptionService.handleDBExceptions(error);
+    }
+  }
+
+  async findToday() {
+    const start = new Date();
+    start.setHours(0, 0, 0, 0);
+
+    const end = new Date();
+    end.setHours(23, 59, 59, 999);
+
+    winstonLogger.debug(`[RoutesService] Searching for today's routes between ${start.toISOString()} and ${end.toISOString()}`);
+
+    try {
+      const routes = await this.routeRepository.find({
+        where: {
+          routeDate: Between(start, end),
+        },
+        relations: ['assignment', 'assignment.vehicle', 'assignment.driver'],
+      });
+
+      winstonLogger.info(`[RoutesService] Found ${routes.length} route(s) for today`);
+      return routes;
+    } catch (error) {
+      winstonLogger.error(`[RoutesService] Error retrieving today's routes: ${error.message}`);
       this.exceptionService.handleDBExceptions(error);
     }
   }


### PR DESCRIPTION
# DFP-48 Generar métricas de la aplicación
## 1. Descripción general
Crear endpoint GET `/api/dashboard/metrics` para obtener una serie de métricas relacionada con el estado operativo del sistema. (Usuarios creados, Viajes del dia de hoy, Vehiculos creados y Conductores creados)

## 2. Solicitud
EndPoint: GET `/api/dashboard/metrics`

## 3. Criterios de aceptación
✅ Retorna 200 OK con el objeto completo
```
{
    "users": 3,
    "vehicles": 5,
    "drivers": 5,
    "routesToday": 1
}
```
## 4. Recursos
N/A