### PR TITLE
DFP 34 Listar vehículos

### DIFF
--- a/front-end/src/pages/vehicles/VehicleIndex.jsx
+++ b/front-end/src/pages/vehicles/VehicleIndex.jsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+import { GenericIndex } from "../components/GenericIndex"; 
+import { Toast } from "../../components/Toast"; 
+
+const baseRoute = import.meta.env.VITE_API_URL; 
+
+export const VehicleIndex = () => {
+  const [data, setData] = useState({});
+  const [loading, setLoading] = useState(true);
+  const [toast, setToast] = useState(null);
+
+  const showToast = (message, type = "error") => {
+    setToast({ message, type });
+    setTimeout(() => setToast(null), 3000);
+  };
+
+  async function getVehicles() {
+    try {
+      const res = await fetch(`${baseRoute}/api/vehicles`, {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("authToken")}`, // Send the authentication token.
+        },
+      });
+      if (!res.ok) throw new Error("Failed to fetch vehicles");
+      const data = await res.json();
+
+     const rows = data.map((v) => [
+        v.id, // Vehicle ID (hidden in the table, used for actions).
+        v.brand,
+        v.model,
+        v.vin, // Vehicle identification number.
+        v.licensePlate,
+      ]);
+
+      return rows;
+    } catch (err) {
+      showToast(err.message);
+      return [];
+    }
+  }
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      const values = await getVehicles();
+      setData({
+        headers: ["Brand", "Model", "VIN", "License Plate"],
+        values,
+      });
+      setLoading(false);
+    };
+    load(); 
+  }, []); 
+
+  return (
+    <>
+      {/* Renders the Toast component if there is an active message. */}
+      {toast && <Toast message={toast.message} type={toast.type} onClose={() => setToast(null)} />}
+      {/* Displays a loading message or the vehicle index. */}
+      {loading ? <p className="text-center">Loading...</p> : <GenericIndex resource="Vehicle" data={data} />}
+    </>
+  );
+};


### PR DESCRIPTION
# DFP-34: Listar vehículos

## 1. Descripción general
Página para mostrar un listado de todos los vehículos registrados.

## 2. Solicitud

- Consumir el endpoint de listado de vehículos.
- Renderizar una tabla o lista con las propiedades clave de cada vehículo.
- Incluir estado de carga y manejo de errores.

## 3. Criterios de aceptación
✅ Aparecen todos los vehículos obtenidos de la API.
✅ Se muestra indicador de carga mientras llegan los datos.
✅ En caso de error, se muestra una notificación al usuario.

## 4. Recursos
N/A