### PR TITLE
DFP 36 Listar Conductores

### DIFF
--- a/front-end/src/pages/drivers/DriverIndex.jsx
+++ b/front-end/src/pages/drivers/DriverIndex.jsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import { GenericIndex } from "../components/GenericIndex"; 
+import { Toast } from "../../components/Toast";
+
+const baseRoute = import.meta.env.VITE_API_URL; 
+
+export const DriverIndex = () => {
+  const [data, setData] = useState({}); 
+  const [loading, setLoading] = useState(true); 
+  const [toast, setToast] = useState(null); 
+
+  const showToast = (message, type = "error") => {
+    setToast({ message, type });
+    setTimeout(() => setToast(null), 3000);
+  };
+
+  async function getDrivers() {
+    try {
+      const res = await fetch(`${baseRoute}/api/drivers`, {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("authToken")}`, 
+        },
+      });
+      if (!res.ok) throw new Error("Failed to fetch drivers"); 
+      const data = await res.json();
+
+      const rows = data.map((d) => [
+        d.id, 
+        d.fullName,
+        d.birthdate.split("T")[0],
+        d.licenseNumber,
+      ]);
+
+      return rows;
+    } catch (err) {
+      showToast(err.message); 
+      return []; 
+    }
+  }
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true); 
+      const values = await getDrivers();
+      setData({
+        headers: ["Full Name", "Birthdate", "License Number"], 
+        values,
+      });
+      setLoading(false);
+    };
+    load(); 
+  }, []); 
+
+  return (
+    <>
+      {}
+      {toast && <Toast message={toast.message} type={toast.type} onClose={() => setToast(null)} />}
+      {}
+      {loading ? (
+        <p className="text-center">Loading...</p>
+      ) : (
+        <GenericIndex resource="Driver" data={data} /> 
+      )}
+    </>
+  );
+};


### PR DESCRIPTION
# DFP-36: Listar Conductores

## 1. Descripción general
Página para mostrar un listado de todos los conductores registrados.

## 2. Solicitud
- Consumir el endpoint de listado de conductores.
- Renderizar los datos en tabla o lista.
- Manejar estado de carga y errores.

## 3. Criterios de aceptación
✅ Se muestran todos los conductores devueltos por la API.
✅ Indicador de carga visible mientras se obtienen los datos.
✅ Notificación al usuario en caso de fallo.

## 4. Recursos
N/A